### PR TITLE
Const correction fix on new compiler

### DIFF
--- a/strlib.inc
+++ b/strlib.inc
@@ -375,7 +375,7 @@ forward _strlib_funcinc();
 public _strlib_funcinc() {
 	new temp[1];
 	
-	format(!"", 0, !"");
+	format(!temp, 0, !temp);
 	strcat(temp, temp);
 	strpack(temp, temp);
 	strunpack(temp, temp);


### PR DESCRIPTION
``strlib.inc:378 (warning) literal array/string passed to a non-const parameter``