### PR TITLE
Fix unused return value warning on compiler 3.10.11

### DIFF
--- a/strlib.inc
+++ b/strlib.inc
@@ -1071,12 +1071,13 @@ stock bool:strfromliteral(output[], const input[], &pos = 0, maxlength = sizeof(
 	
 	pos++;
 	
-	new bool:ret;
-	
+	new bool:ret = true;
+	#pragma unused ret
+
 	goto return_true;
-return_true:
-	ret = true;
 return_false:
+	ret = false;
+return_true:
 
 	if (heap)
 		RestoreHeapToAddress(heap);

--- a/strlib.inc
+++ b/strlib.inc
@@ -1071,12 +1071,12 @@ stock bool:strfromliteral(output[], const input[], &pos = 0, maxlength = sizeof(
 	
 	pos++;
 	
-	new bool:ret = true;
+	new bool:ret;
 	
 	goto return_true;
-return_false:
-	ret = false;
 return_true:
+	ret = true;
+return_false:
 
 	if (heap)
 		RestoreHeapToAddress(heap);


### PR DESCRIPTION
Y_Less confirmed it's a bug in the compiler but he also said it should be patched in the library as well.
This should get rid of the warning.

The warning for reference:
```
strlib\strlib.inc:1074 (warning) assigned value is never used (symbol "ret")
```