### PR TITLE
Remove useless ++

### DIFF
--- a/strlib.inc
+++ b/strlib.inc
@@ -1405,7 +1405,7 @@ stock utf8encode(dest[], const source[], maxlength = sizeof(dest)) {
 		}
 	}
 	
-	dest[idx++] = '\0';
+	dest[idx] = '\0';
 	
 	if (heap) {
 		RestoreHeapToAddress(heap);
@@ -1474,7 +1474,7 @@ stock utf8decode(dest[], const source[], maxlength = sizeof(dest)) {
 		}
 	}
 	
-	dest[idx++] = 0;
+	dest[idx] = 0;
 	
 	if (heap) {
 		RestoreHeapToAddress(heap);


### PR DESCRIPTION
This is a little fix to be served in the open.mp compiler upgrade, `idx` is no longer used and does'nt need to be increased at the end.